### PR TITLE
feat: enhance OpenRouter plugin with AI SDK v5 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-openrouter",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "type": "module",
   "main": "dist/cjs/index.node.cjs",
   "module": "dist/node/index.node.js",
@@ -133,6 +133,13 @@
         "description": "Whether to automatically cleanup generated images after a short delay.",
         "required": false,
         "default": false,
+        "sensitive": false
+      },
+      "OPENROUTER_TOOL_EXECUTION_MAX_STEPS": {
+        "type": "number",
+        "description": "Maximum number of steps for multi-step tool execution. Allows the AI to generate descriptive text after calling tools in AI SDK v5.",
+        "required": false,
+        "default": 15,
         "sensitive": false
       }
     }

--- a/src/models/image.ts
+++ b/src/models/image.ts
@@ -59,7 +59,7 @@ export async function handleImageDescription(
     const { text: responseText } = await generateText({
       model: model,
       messages: messages,
-      maxOutputTokens: maxOutputTokens,
+      maxTokens: maxOutputTokens,
     });
 
     return parseImageDescriptionResponse(responseText);

--- a/src/models/object.ts
+++ b/src/models/object.ts
@@ -35,7 +35,8 @@ async function generateObjectWithModel(
   try {
     const { object, usage } = await generateObject({
       model: openrouter.chat(modelName),
-      output: "no-schema",
+      ...(params.schema && { schema: params.schema }),
+      output: (params.schema ? "object" : "no-schema") as any,
       prompt: params.prompt,
       temperature: temperature,
       experimental_repairText: getJsonRepairFunction(),

--- a/src/models/text.ts
+++ b/src/models/text.ts
@@ -5,7 +5,7 @@ import type { Tool, ToolChoice } from "ai";
 
 import { createOpenRouterProvider } from "../providers";
 import type { ToolCall, ToolResponse, ToolResult } from "../types";
-import { getSmallModel, getLargeModel } from "../utils/config";
+import { getSmallModel, getLargeModel, getToolExecutionMaxSteps } from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
 import { handleEmptyToolResponse, decodeBase64Fields } from "../utils/helpers";
 
@@ -55,6 +55,9 @@ async function generateTextWithModel(
   // Add tools if provided
   if (tools) {
     (generateParams as any).tools = tools;
+    const maxSteps = getToolExecutionMaxSteps(runtime);
+    (generateParams as any).maxSteps = maxSteps;
+    logger.log(`[OpenRouter] Using maxSteps: ${maxSteps} for tool execution`);
   }
 
   // Add toolChoice if provided

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -122,3 +122,22 @@ export function shouldAutoCleanupImages(runtime: IAgentRuntime): boolean {
   );
   return setting?.toLowerCase() === "true";
 }
+
+/**
+ * Helper function to get the max steps for tool execution
+ *
+ * @param runtime The runtime context
+ * @returns The maximum number of steps for tool execution (default: 15)
+ */
+export function getToolExecutionMaxSteps(runtime: IAgentRuntime): number {
+  const setting = getSetting(
+    runtime,
+    "OPENROUTER_TOOL_EXECUTION_MAX_STEPS",
+    "15",
+  );
+  const value = parseInt(setting || "15", 10);
+  // Ensure valid range (1-100)
+  if (Number.isNaN(value) || value < 1) return 15;
+  if (value > 100) return 100;
+  return value;
+}

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -22,8 +22,8 @@ export function emitModelUsageEvent(
         : prompt
       : "";
   // Coalesce optional usage fields to stable numbers
-  const inputTokens = Number(usage.inputTokens || 0);
-  const outputTokens = Number(usage.outputTokens || 0);
+  const inputTokens = Number((usage as { inputTokens?: number }).inputTokens || 0);
+  const outputTokens = Number((usage as { outputTokens?: number }).outputTokens || 0);
   const totalTokens = Number(
     usage.totalTokens != null ? usage.totalTokens : inputTokens + outputTokens,
   );


### PR DESCRIPTION
- Bump to version 1.5.11
- Add configurable max steps for tool execution (OPENROUTER_TOOL_EXECUTION_MAX_STEPS)
- Fix AI SDK v5 compatibility issues:
  - Update generateText to use maxTokens instead of maxOutputTokens
  - Fix generateObject output parameter handling
  - Add maxSteps parameter for multi-step tool execution
- Improve TypeScript type handling in usage events
- Default tool execution max steps to 15 with range validation (1-100)